### PR TITLE
AUTH-15 Sevice responds with 500 when passing card with application scope

### DIFF
--- a/core/handlers/grant.go
+++ b/core/handlers/grant.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/VirgilSecurity/virgil-services-auth/core"
 	"github.com/VirgilSecurity/virgil-services-auth/db"
-	"github.com/pkg/errors"
 	virgil "gopkg.in/virgil.v4"
+	verrors "gopkg.in/virgil.v4/errors"
 	"gopkg.in/virgil.v4/virgilcrypto"
 )
 
@@ -35,11 +35,19 @@ type Grant struct {
 func (s *Grant) Handshake(resp core.Response, ownerCard core.OwnerCard) {
 	card, err := s.Client.GetCard(ownerCard.ID)
 	if err != nil {
-		verr := errors.Cause(err)
-		if verr == virgil.ErrNotFound {
-			resp.Error(core.StatusErrorCardNotFound)
-			return
+		if verr, ok := verrors.ToSdkError(err); ok {
+			// Card not found
+			if verr == virgil.ErrNotFound {
+				resp.Error(core.StatusErrorCardNotFound)
+				return
+			}
+			// Card found but permission denied
+			if verr.IsHTTPError() && (verr.HTTPErrorCode() == 401 || verr.HTTPErrorCode() == 403) {
+				resp.Error(core.StatusErrorCardNotFound)
+				return
+			}
 		}
+
 		if strings.Contains(err.Error(), "does not have signature for verifier ID") || strings.Contains(err.Error(), "signature validation failed") {
 			resp.Error(core.StatusErrorCardInvalid)
 			return

--- a/core/handlers/grant_test.go
+++ b/core/handlers/grant_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	virgil "gopkg.in/virgil.v4"
+	"gopkg.in/virgil.v4/errors"
 	"gopkg.in/virgil.v4/virgilcrypto"
 
 	"github.com/VirgilSecurity/virgil-services-auth/core"
@@ -104,6 +105,32 @@ func TestHandshake_CardNotFound_ReturnCardNotFoundStat(t *testing.T) {
 
 	c := new(FakeCardClient)
 	c.On("GetCard", mock.Anything).Return(nil, virgil.ErrNotFound)
+
+	s := Grant{Client: c}
+	s.Handshake(resp, core.OwnerCard{ID: "id"})
+
+	resp.AssertExpectations(t)
+}
+
+func TestHandshake_CardProtected401_ReturnCardNotFoundStat(t *testing.T) {
+	resp := new(FakeResponse)
+	resp.On("Error", core.StatusErrorCardNotFound).Once()
+
+	c := new(FakeCardClient)
+	c.On("GetCard", mock.Anything).Return(nil, errors.NewServiceError(20300, 401, ""))
+
+	s := Grant{Client: c}
+	s.Handshake(resp, core.OwnerCard{ID: "id"})
+
+	resp.AssertExpectations(t)
+}
+
+func TestHandshake_CardProtected403_ReturnCardNotFoundStat(t *testing.T) {
+	resp := new(FakeResponse)
+	resp.On("Error", core.StatusErrorCardNotFound).Once()
+
+	c := new(FakeCardClient)
+	c.On("GetCard", mock.Anything).Return(nil, errors.NewServiceError(20500, 403, ""))
 
 	s := Grant{Client: c}
 	s.Handshake(resp, core.OwnerCard{ID: "id"})


### PR DESCRIPTION
added condition that card must be available for the service (status code of response not equal 401 403 of the cards service) otherwise return Card not found error